### PR TITLE
Add logging endpoint

### DIFF
--- a/api.js
+++ b/api.js
@@ -224,6 +224,28 @@ module.exports = function (options, connectionListener) {
 		}
 	})
 
+	// A dedicated log endpoint to log messages send by clients if logging is enabled.
+	app.post(urlRoot + '/log', jsonParser, function (req, res) {
+		var message = req.body?.message,
+			token = req.body?.token;
+
+		if (!message || typeof token !== 'string') {
+			res.sendStatus(400)
+			return
+		}
+
+		if (!sockets[token]) {
+			if (token.length === 64) {
+				token = `unknown-${token}`
+			} else {
+				token = "???"
+			}
+		}
+
+		myLog(`Client Log (${token}): ${message}`);
+		res.sendStatus(200);
+	})
+
 	var wss = expressWs(app, server);
 
 	// Add dedicated WebSocket ping endpoint
@@ -293,10 +315,6 @@ module.exports = function (options, connectionListener) {
 		ws.on('message', function (data) {
 			if (typeof data === 'string' && data.startsWith('ping:')) {
 				ws.send('pong:' + data.slice('ping:'.length), () => {});
-				return
-			}
-			if (typeof data === 'string' && data.startsWith('proxy-log:')) {
-				myLog(`Client Log (${token}): ${data.slice('proxy-log:'.length)}`)
 				return
 			}
 

--- a/api.js
+++ b/api.js
@@ -295,6 +295,10 @@ module.exports = function (options, connectionListener) {
 				ws.send('pong:' + data.slice('ping:'.length), () => {});
 				return
 			}
+			if (typeof data === 'string' && data.startsWith('proxy-log:')) {
+				myLog(`Client Log (${token}): ${data.slice('proxy-log:'.length)}`)
+				return
+			}
 
 			packetsLastSecond.fromClient++;
 			checkPacketRate();


### PR DESCRIPTION
They get logged together with the clients socket token in the proxys log, if enabled (via `--log` or `LOG` env var)

To log a message, the package exports a `logProxy` method which can be called [right here](https://github.com/zardoy/minecraft-web-client/blob/e757e1ae91caf76eee8e7f2ae11cec6041bba013/src/index.ts#L582) for example.